### PR TITLE
Color highlight on the name of the failed tests

### DIFF
--- a/_pytest/terminal.py
+++ b/_pytest/terminal.py
@@ -458,7 +458,8 @@ class TerminalReporter:
                     self.write_line(line)
                 else:
                     msg = self._getfailureheadline(rep)
-                    self.write_sep("_", msg)
+                    markup = {'red': True, 'bold': True}
+                    self.write_sep("_", msg, **markup)
                     self._outrep_summary(rep)
 
     def summary_errors(self):


### PR DESCRIPTION
I'm proposing this small enhancement because it is sometimes difficult, especially when using verbose tests output, to immediately spot which tests are failing in the middle of all the tracebacks and other output messages. I believe by highlighting the separator line containing the test name which is failing in red would allow developers to quickly spot the failed test and target where his next action should be.