### PR TITLE
Move comment in tox.ini due to recent bug in pip

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -16,9 +16,10 @@ deps=
 
 [testenv:py26]
 commands= py.test --lsof -rfsxX {posargs:testing}
+# pinning mock to last supported version for python 2.6
 deps=
     nose
-    mock<1.1  # last supported version for py26
+    mock<1.1
 
 [testenv:py27-subprocess]
 changedir=.


### PR DESCRIPTION
As discussed in #1554

* https://bitbucket.org/hpk42/tox/issues/332/
* https://github.com/pypa/pip/issues/3667