### PR TITLE
Prepare release 5.3.6

### DIFF
--- a/doc/en/announce/index.rst
+++ b/doc/en/announce/index.rst
@@ -6,6 +6,7 @@ Release announcements
    :maxdepth: 2
 
 
+   release-5.3.6
    release-5.3.5
    release-5.3.4
    release-5.3.3

--- a/doc/en/announce/release-5.3.6.rst
+++ b/doc/en/announce/release-5.3.6.rst
@@ -1,0 +1,18 @@
+pytest-5.3.6
+=======================================
+
+pytest 5.3.6 has just been released to PyPI.
+
+This is a bug-fix release, being a drop-in replacement. To upgrade::
+
+  pip install --upgrade pytest
+
+The full changelog is available at https://docs.pytest.org/en/latest/changelog.html.
+
+Thanks to all who contributed to this release, among them:
+
+* Daniel Hahler
+
+
+Happy testing,
+The pytest Development Team

--- a/doc/en/changelog.rst
+++ b/doc/en/changelog.rst
@@ -28,6 +28,12 @@ with advance notice in the **Deprecations** section of releases.
 
 .. towncrier release notes start
 
+pytest 5.3.6 (2020-02-26)
+=========================
+
+No significant changes.
+
+
 pytest 5.3.5 (2020-01-29)
 =========================
 

--- a/doc/en/example/parametrize.rst
+++ b/doc/en/example/parametrize.rst
@@ -475,8 +475,11 @@ Running it results in some skips if we don't have all the python interpreters in
 .. code-block:: pytest
 
    . $ pytest -rs -q multipython.py
-   ...........................                                          [100%]
-   27 passed in 0.12s
+   ssssssssssss...ssssssssssss                                          [100%]
+   ========================= short test summary info ==========================
+   SKIPPED [12] $REGENDOC_TMPDIR/CWD/multipython.py:29: 'python3.5' not found
+   SKIPPED [12] $REGENDOC_TMPDIR/CWD/multipython.py:29: 'python3.7' not found
+   3 passed, 24 skipped in 0.12s
 
 Indirect parametrization of optional implementations/imports
 --------------------------------------------------------------------


### PR DESCRIPTION
Created automatically from https://github.com/nicoddemus/pytest/issues/32.

Once all builds pass and it has been **approved** by one or more maintainers, the build
can be released by pushing a tag `5.3.6` to this repository.
